### PR TITLE
Fix config paths for stubbed function

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,10 @@ Read these documents before making major edits or when unsure about the process.
 
 1. Identify the function to decompile in `DecompStart/fromgame/asm`.
 2. Look in `DecompReference/` for similar implementations.
-3. Create or update a source file in `src/` matching the function.
+3. Create or update a source file in `src/` matching the function. For early
+   work placed under `DecompStart`, place C or C++ files in
+   `DecompStart/src` and any headers (such as `macros.h`) in
+   `DecompStart/include`.
 4. Update `configure.py` and `splits.txt` to point to the new file.
 5. Add the symbol to `symbols.txt` if needed.
 6. Run `python configure.py` and then `ninja` to build.

--- a/DecompStart/include/macros.h
+++ b/DecompStart/include/macros.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#define MAX(x, y) ((x) > (y) ? (x) : (y))
+#define MIN(x, y) ((x) < (y) ? (x) : (y))
+
+#define CLAMP(low, high, x)                                                    \
+    ((x) > (high) ? (high) : ((x) < (low) ? (low) : (x)))
+
+#define ROUND_UP(x, align) (((x) + (align) - 1) & (-(align)))
+#define ROUND_UP_PTR(x, align)                                                 \
+    ((void*)((((u32)(x)) + (align) - 1) & (~((align) - 1))))
+
+#define ROUND_DOWN(x, align) ((x) & (-(align)))
+#define ROUND_DOWN_PTR(x, align) ((void*)(((u32)(x)) & (~((align) - 1))))
+
+#define ARRAY_SIZE(x) (sizeof((x)) / sizeof((x)[0]))
+
+#define MEMCLR(x) __memclr((x), sizeof(*(x)))
+
+#define ALIGN(x) __attribute__((aligned(x)))
+
+#define DECL_SECTION(x) __declspec(section x)
+#define DECL_WEAK __declspec(weak)
+
+#define DECLTYPE(x) __decltype__(x)
+
+// https://github.com/DarkRTA/rb3/blob/235050f88a263fec0387b7c618dda76a8bb24d2c/src/sdk/RVL_SDK/revolution/os/OSUtils.h#L13-L17
+#if defined(__CWCC__) && !defined(__INTELLISENSE__)
+#define AT_ADDRESS(addr) : (addr)
+#else
+#define AT_ADDRESS(addr)
+#endif
+
+// For VSCode
+#ifdef __INTELLISENSE__
+#define asm
+#define __attribute__(x)
+#define __declspec(x)
+#endif

--- a/DecompStart/src/fn_800A1CA0.c
+++ b/DecompStart/src/fn_800A1CA0.c
@@ -1,0 +1,7 @@
+#include "macros.h"
+
+void fn_8001CB64(void);
+
+void fn_800A1CA0(void) {
+    fn_8001CB64();
+}

--- a/config/SPDE52/splits.txt
+++ b/config/SPDE52/splits.txt
@@ -20,3 +20,6 @@ Runtime.PPCEABI.H/__init_cpp_exceptions.cpp:
         .dtors      start:0x80325844 end:0x80325848 rename:.dtors$15
         .sdata      start:0x806A6C78 end:0x806A6C80
 
+DecompStart/src/fn_800A1CA0.c:
+        .text       start:0x800A1CA0 end:0x800A1CA4
+

--- a/config/SPDE52/splits.txt
+++ b/config/SPDE52/splits.txt
@@ -13,13 +13,12 @@ Sections:
 	.sdata2     type:rodata align:8
 	.sbss2      type:bss align:16
 
-Runtime.PPCEABI.H/__init_cpp_exceptions.cpp:
-        .text       start:0x80228940 end:0x802289B0
-        .ctors      start:0x80325700 end:0x80325704 rename:.ctors$10
-        .dtors      start:0x80325840 end:0x80325844 rename:.dtors$10
-        .dtors      start:0x80325844 end:0x80325848 rename:.dtors$15
-        .sdata      start:0x806A6C78 end:0x806A6C80
-
 DecompStart/src/fn_800A1CA0.c:
-        .text       start:0x800A1CA0 end:0x800A1CA4
+	.text       start:0x800A1CA0 end:0x800A1CA4
 
+Runtime.PPCEABI.H/__init_cpp_exceptions.cpp:
+	.text       start:0x80228940 end:0x802289B0
+	.ctors      start:0x80325700 end:0x80325704 rename:.ctors$10
+	.dtors      start:0x80325840 end:0x80325844 rename:.dtors$10
+	.dtors      start:0x80325844 end:0x80325848 rename:.dtors$15
+	.sdata      start:0x806A6C78 end:0x806A6C80

--- a/configure.py
+++ b/configure.py
@@ -211,6 +211,7 @@ cflags_base = [
     "-str reuse",
     "-multibyte",  # For Wii compilers, replace with `-enc SJIS`
     "-i include",
+    "-i DecompStart/include",
     f"-i build/{config.version}/include",
     f"-DBUILD_VERSION={version_num}",
     f"-DVERSION_{config.version}",
@@ -294,6 +295,15 @@ config.libs = [
         "objects": [
             Object(NonMatching, "Runtime.PPCEABI.H/global_destructor_chain.c"),
             Object(NonMatching, "Runtime.PPCEABI.H/__init_cpp_exceptions.cpp"),
+        ],
+    },
+    {
+        "lib": "DecompStart",
+        "mw_version": config.linker_version,
+        "cflags": cflags_base,
+        "progress_category": "game",
+        "objects": [
+            Object(Equivalent, "DecompStart/src/fn_800A1CA0.c"),
         ],
     },
 ]


### PR DESCRIPTION
## Summary
- add include path for DecompStart headers
- compile stubbed `fn_800A1CA0` from DecompStart
- map stubbed function range in `splits.txt`

## Testing
- `python3 configure.py configure -v SPDE52 --verbose`
- `ninja -j1` *(fails: `orig/SPDE52/sys/main.dol` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68755218fb488325854e5743d740f798