### PR TITLE
Fix assembler flags and document usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ General:
 
 - [Common BSS](docs/common_bss.md)
 - [`.comment` section](docs/comment_section.md)
+- [Assembler](docs/assembler.md)
 
 References
 --------

--- a/configure.py
+++ b/configure.py
@@ -170,8 +170,13 @@ config.asflags = [
     "-mgekko",
     "--strip-local-absolute",
     "-I include",
+    "-I DecompStart/include",
+    "-I src",
+    "-I DecompStart/src",
     f"-I build/{config.version}/include",
+    f"-I build/{config.version}/src",
     f"--defsym BUILD_VERSION={version_num}",
+    f"--defsym VERSION_{config.version}",
 ]
 config.ldflags = [
     "-fp hardware",
@@ -212,7 +217,10 @@ cflags_base = [
     "-multibyte",  # For Wii compilers, replace with `-enc SJIS`
     "-i include",
     "-i DecompStart/include",
+    "-i src",
+    "-i DecompStart/src",
     f"-i build/{config.version}/include",
+    f"-i build/{config.version}/src",
     f"-DBUILD_VERSION={version_num}",
     f"-DVERSION_{config.version}",
 ]

--- a/docs/assembler.md
+++ b/docs/assembler.md
@@ -1,0 +1,30 @@
+# Assembly sources
+
+The project supports building standalone PowerPC assembly files. The assembler
+flags in `configure.py` list all necessary include and source directories so that
+both the build system and `objdiff` can locate headers and generated files.
+
+## Adding a `.s` file
+
+1. Place your assembly file under `DecompStart/src` (or `src` when the project
+   moves out of `DecompStart`).
+2. Add the file to the object list in `configure.py`. For example:
+
+   ```python
+   Object(Equivalent, "DecompStart/src/example.s"),
+   ```
+3. Add the corresponding ranges to `config/[GAMEID]/splits.txt`.
+
+Run `python configure.py` followed by `ninja` to assemble the file.
+
+## Viewing with objdiff
+
+After the build completes, the new object will appear in
+`build/[GAMEID]/`. Use `objdiff` to compare it against the original object:
+
+```
+objdiff build/[GAMEID]/example.o orig/[GAMEID]/example.o
+```
+
+`configure.py` generates `objdiff.json` with the assembler flags, so objdiff can
+assemble the source and show accurate diffs.


### PR DESCRIPTION
## Summary
- include DecompStart and source paths in `configure.py` assembler flags
- add matching source paths to compiler flags
- document assembler usage
- link new docs in README

## Testing
- `ninja -n`
- `ninja` *(fails: orig/SPDE52/sys/main.dol not found)*

------
https://chatgpt.com/codex/tasks/task_e_68756a6d0c9083258adbb37d824a388f